### PR TITLE
font: use rsfs for spin operator

### DIFF
--- a/structure.tex
+++ b/structure.tex
@@ -40,9 +40,9 @@
 
 \usepackage{mathtools} % For *rcases* environment
 \usepackage[scr=boondoxo, scrscaled=1]{mathalfa}
-%\usepackage{mathrsfs}
+\usepackage{mathrsfs}
 %\usepackage{mathptmx}
-\usepackage{mathpazo}
+%\usepackage{mathpazo}
 %\usepackage{old-arrows} % 
 %\usepackage[T1]{fontenc}
 %\usepackage{newpxtext,newpxmath}

--- a/structure.tex
+++ b/structure.tex
@@ -39,10 +39,10 @@
 \usepackage{bm}
 
 \usepackage{mathtools} % For *rcases* environment
-\usepackage[scr=boondoxo, scrscaled=1]{mathalfa}
-\usepackage{mathrsfs}
+\usepackage[scr=rsfs, scrscaled=1]{mathalfa}
+%\usepackage{mathrsfs}
 %\usepackage{mathptmx}
-%\usepackage{mathpazo}
+\usepackage{mathpazo}
 %\usepackage{old-arrows} % 
 %\usepackage[T1]{fontenc}
 %\usepackage{newpxtext,newpxmath}

--- a/structure.tex
+++ b/structure.tex
@@ -39,7 +39,8 @@
 \usepackage{bm}
 
 \usepackage{mathtools} % For *rcases* environment
-\usepackage[scr=rsfs, scrscaled=1]{mathalfa}
+\usepackage[scr=boondoxo, scrscaled=1]{mathalfa}
+\DeclareMathAlphabet{\mathrsfs}{U}{rsfs}{m}{n}
 %\usepackage{mathrsfs}
 %\usepackage{mathptmx}
 \usepackage{mathpazo}
@@ -234,7 +235,8 @@
 \newcommand{\bfr}{\mathbf{r}}
 \newcommand{\heh}{\mathrm{HeH}^+}
 \newcommand{\au}{\,\mathrm{a.u.}}
-\newcommand{\ts}{\mathscr{S}} %总自旋算符
+%\newcommand{\ts}{\mathscr{S}} %总自旋算符
+\newcommand{\ts}{\mathrsfs{S}}
 \usepackage{xeCJKfntef} % the package containing the command \CJKuderline*{} for the \mci command
 \newcommand{\mci}[1]{\CJKunderline{#1}}
 \newcommand{\phrase}[1]{\CJKunderline{#1}}


### PR DESCRIPTION
`S` in the font rsfs(provided by macro package `mathrsfs`) looks more similar with szabo the book than the font provided by `mathpazo`; this PR subtitutes the macro package `mathpazo` to `mathrsfs`. 
This PR origins from the issue #54 .